### PR TITLE
Add no perm error and redirect after loading

### DIFF
--- a/inc/plugins/miserablemember.php
+++ b/inc/plugins/miserablemember.php
@@ -18,7 +18,7 @@ function miserablemember_info()
 		"website"		=> "https://github.com/PenguinPaul/miserable-member",
 		"author"		=> "Paul H.",
 		"authorsite"	=> "http://www.paulhedman.com",
-		"version"		=> "1.0",
+		"version"		=> "1.1",
 		"guid" 			=> "",
 		"compatibility" => "*"
 	);


### PR DESCRIPTION
This pull request introduces new cruel punishments for those miserable members.
- Fixes SQL errors on activate (and improves the method of adding settings)
- Chance changes
  - Chance of getting a blank page: 50% -> 40%
  - Chance of being redirected to the homepage: 40% -> 20%
- Introduces a MyBB no permission error with a chance of 20%
- Introduces a redirect to the homepage a random amount of time (between 30 and 180 seconds) after the page has loaded with a chance of 10%
  - When javascript is disabled a meta refresh tag is used to redirect.
  - The user enables javascript at their own peril as when redirected to the homepage the last page visited isn't in the history and so they can't click back to get to the previous page!
